### PR TITLE
Limit Census authorization to 12 years old

### DIFF
--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -18,6 +18,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   validates :document_type, inclusion: { in: %i(DNI NIE PASS) }, presence: true
   validates :document_number, format: { with: /\A[A-z0-9]*\z/ }, presence: true
 
+  validate :over_12
   validate :check_response
 
   # If you need to store any of the defined attributes in the authorization you
@@ -76,5 +77,20 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
       tipdoc: document_type,
       docident: document_number
     }
+  end
+
+  def over_12
+    errors.add(:date_of_birth, I18n.t("census_authorization_handler.age_under_12")) unless age && age >= 12
+  end
+
+  def age
+    return nil if date_of_birth.blank?
+
+    now = Date.current
+    extra_year = (now.month > date_of_birth.month) || (
+      now.month == date_of_birth.month && now.day >= date_of_birth.day
+    )
+
+    now.year - date_of_birth.year - (extra_year ? 0 : 1)
   end
 end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -12,6 +12,8 @@ ca:
         day: "Dia"
         month: "Mes"
         year: "Any"
+  census_authorization_handler:
+    age_under_12: Has de ser major de 12 anys per validar-te
   decidim:
     authorization_handlers:
       census_authorization_handler:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,3 @@
+en:
+  census_authorization_handler:
+    age_under_12: You must be 12 years old at least in order to be verified.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -12,6 +12,8 @@ es:
         day: "Día"
         month: "Mes"
         year: "Año"
+  census_authorization_handler:
+    age_under_12: Tienes que ser mayor de 12 años para validarte
   decidim:
     authorization_handlers:
       census_authorization_handler:

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -76,6 +76,18 @@ describe CensusAuthorizationHandler do
 
         it { is_expected.not_to be_valid }
       end
+
+      context "when the age is below 12" do
+        let(:date_of_birth) { 11.years.ago.to_date }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the age is over or equal to 12" do
+        let(:date_of_birth) { 12.years.ago.to_date }
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context "when everything is fine" do


### PR DESCRIPTION
#### :tophat: What? Why?

For the next process only people over 12 year should be able to be verified. After the process ends we'll reset all authorizations so we don't have minors with a valid authorization.
